### PR TITLE
Fix sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ make unittest
 ```markdown
 cd go/
 make vet
+# https://staticcheck.io/
 make staticscan
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repository is to contribute to people like me.
 * [Tutorials](#tutorials)
   * [How to run examples](#how-to-run-examples)
   * [How to run tests](#how-to-run-tests)
+  * [How to run lint](#how-to-run-lint)
 * [Available environment variables](#available-environment-variables)
+  * [admin/report](#adminreport)
 
 ## Available examples
 

--- a/sdks/go/examples/quickstarts/admin/report/main.go
+++ b/sdks/go/examples/quickstarts/admin/report/main.go
@@ -62,7 +62,7 @@ func main() {
 		pageCnt++
 		nextPageToken = resp.NextPageToken
 
-		time.Sleep(5)
+		time.Sleep(5 * time.Second)
 	}
 
 	log.Printf("Finished polling.")


### PR DESCRIPTION
Fix
```markdown
(venv) [ywatanabe@laptop-archlinux go]$ make staticcheck
staticcheck ./...
examples/quickstarts/admin/report/main.go:65:14: sleeping for 5 nanoseconds is probably a bug; be explicit if it isn't (SA1004)
make: *** [Makefile:9: staticcheck] Error 1

```